### PR TITLE
Add "http-proxy" to portrule

### DIFF
--- a/http-log4shell.nse
+++ b/http-log4shell.nse
@@ -22,7 +22,7 @@ license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 categories = {"default", "vuln", "safe", "log4shell"}
 
 -- portrule = shortport.http
-portrule = shortport.port_or_service({80,443,8080}, {"http","https"})
+portrule = shortport.port_or_service({80,443,8080}, {"http","https","http-proxy"})
 
 action = function(host, port)
   local resp, redirect_url, title


### PR DESCRIPTION
First of all: Thank you for the NSE script!
We have tested it against the following vulnerable HTTP server: https://github.com/christophetd/log4shell-vulnerable-app

However, nmap detects the service as "http-proxy" and not "http" or "https" and therefore the NSE script won't run. We think it might make sense to also add "http-proxy" to the portrule.

PS: https://github.com/christophetd/log4shell-vulnerable-app runs on port 8080, so your script acutally ran. But for cases in which a vulnerable server does not run on port 80, 443 or 8080 or is not detected as "http" or "https", the script would return a false negative.