### PR TITLE
Usage of portrule = shortport.http

### DIFF
--- a/http-log4shell.nse
+++ b/http-log4shell.nse
@@ -21,8 +21,7 @@ license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
 
 categories = {"default", "vuln", "safe", "log4shell"}
 
--- portrule = shortport.http
-portrule = shortport.port_or_service({80,443,8080}, {"http","https","http-proxy"})
+portrule = shortport.http
 
 action = function(host, port)
   local resp, redirect_url, title


### PR DESCRIPTION
I would consider changing the portrule to `portrule = shortport.http`. This will run the script against the following ports and services (according to https://github.com/nmap/nmap/blob/master/nselib/shortport.lua):

LIKELY_HTTP_PORTS = {
  80, 443, 631, 7080, 8080, 8443, 8088, 5800, 3872, 8180, 8000
}

LIKELY_HTTP_SERVICES = {
  "http", "https", "ipp", "http-alt", "https-alt", "vnc-http", "oem-agent",
  "soap", "http-proxy", "caldav", "carddav", "webdav",
}